### PR TITLE
Static special methods bugfix

### DIFF
--- a/src/rr/instrument/hooks/SpecialMethods.java
+++ b/src/rr/instrument/hooks/SpecialMethods.java
@@ -134,7 +134,9 @@ public class SpecialMethods implements Opcodes {
 		String className = "__$rr_TSRThunk_" + enclosing.getOwner().getName().replace('/', '_') + "_" + thunkCount++;
 		thunkType = Type.getObjectType(className);
 		Method invokeMethod = new Method("invoke", method.getDescriptor());
-		invokeMethod = new Method("invoke", ASMUtil.addTypeToDescriptor(invokeMethod.getDescriptor(), Type.getObjectType(method.getOwner().getName().replace('.','/')), 0));
+		if (opcode != INVOKESTATIC) {
+			invokeMethod = new Method("invoke", ASMUtil.addTypeToDescriptor(invokeMethod.getDescriptor(), Type.getObjectType(method.getOwner().getName().replace('.','/')), 0));
+		}
 
 		gen.invokeStatic(thunkType, invokeMethod);
 


### PR DESCRIPTION
Fixed a bug that generated the wrong descriptor for static special methods for calls in SpecialMethods.tryReplace.  Either ASM crashed trying to compute frames or if ASM didn't choke, the verifier caught it.
