### PR TITLE
Accessed field reference

### DIFF
--- a/src/rr/event/AccessEvent.java
+++ b/src/rr/event/AccessEvent.java
@@ -58,6 +58,11 @@ public abstract class AccessEvent extends Event {
 	 * Is null for static field accesses.
 	 */
 	protected Object target;
+	
+	/** For accesses to reference types, gives the value of the reference
+	 * null for accesses to primitive types
+	 */
+	protected Object accessed;
 
 	/** Whether this access is a read or a write. */
 	protected boolean isWrite;
@@ -98,7 +103,16 @@ public abstract class AccessEvent extends Event {
 	public Object getTarget() {
 		return target;
 	}
+	
+	/** Returns the accessed reference */
+	public Object getAccessed(){
+		return accessed;
+	}
 
+	public void setAccessed(Object accessed){
+		this.accessed = accessed;
+	}
+	
 	/** @RRInternal */
 	public void setTarget(Object target) {
 		this.target = target;

--- a/src/rr/instrument/Constants.java
+++ b/src/rr/instrument/Constants.java
@@ -77,21 +77,21 @@ public class Constants {
 	
 	public static final Method CURRENT_THREAD_METHOD =	new Method("getCurrentShadowThread", THREAD_STATE_TYPE, new Type[] { } );
 	
-	private static final Method READ_ACCESS_METHOD = new Method("readAccess", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	private static final Method WRITE_ACCESS_METHOD = new Method("writeAccess", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	private static final Method VOLATILE_READ_ACCESS_METHOD = new Method("volatileReadAccess", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	private static final Method VOLATILE_WRITE_ACCESS_METHOD = new Method("volatileWriteAccess", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method READ_ACCESS_METHOD = new Method("readAccess", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method WRITE_ACCESS_METHOD = new Method("writeAccess", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method VOLATILE_READ_ACCESS_METHOD = new Method("volatileReadAccess", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method VOLATILE_WRITE_ACCESS_METHOD = new Method("volatileWriteAccess", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
 
 	// for multiple classloaders...
-	private static final Method READ_ACCESS_METHOD_ML = new Method("readAccessML", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	private static final Method WRITE_ACCESS_METHOD_ML = new Method("writeAccessML", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	private static final Method VOLATILE_READ_ACCESS_METHOD_ML = new Method("volatileReadAccessML", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	private static final Method VOLATILE_WRITE_ACCESS_METHOD_ML = new Method("volatileWriteAccessML", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method READ_ACCESS_METHOD_ML = new Method("readAccessML", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method WRITE_ACCESS_METHOD_ML = new Method("writeAccessML", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method VOLATILE_READ_ACCESS_METHOD_ML = new Method("volatileReadAccessML", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	private static final Method VOLATILE_WRITE_ACCESS_METHOD_ML = new Method("volatileWriteAccessML", Type.VOID_TYPE, new Type[] {OBJECT_TYPE, OBJECT_TYPE, GUARD_STATE_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
 
-	public static final Method READ_ARRAY_METHOD = new Method("arrayRead", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	public static final Method READ_ARRAY_WITH_UPDATER_METHOD = new Method("arrayRead", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE, Type.getType(AbstractArrayState.class) });
-	public static final Method WRITE_ARRAY_METHOD = new Method("arrayWrite", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
-	public static final Method WRITE_ARRAY_WITH_UPDATER_METHOD = new Method("arrayWrite", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE, Type.getType(AbstractArrayState.class) });
+	public static final Method READ_ARRAY_METHOD = new Method("arrayRead", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	public static final Method READ_ARRAY_WITH_UPDATER_METHOD = new Method("arrayRead", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE, Type.getType(AbstractArrayState.class) });
+	public static final Method WRITE_ARRAY_METHOD = new Method("arrayWrite", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
+	public static final Method WRITE_ARRAY_WITH_UPDATER_METHOD = new Method("arrayWrite", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE, Type.getType(AbstractArrayState.class) });
 	public static final Method ACQUIRE_METHOD = new Method("acquire", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
 	public static final Method TEST_ACQUIRE_METHOD = new Method("testAcquire", Type.BOOLEAN_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });
 	public static final Method RELEASE_METHOD = new Method("release", Type.VOID_TYPE, new Type[] { OBJECT_TYPE, Type.INT_TYPE, THREAD_STATE_TYPE });

--- a/src/rr/instrument/classes/GuardStateInserter.java
+++ b/src/rr/instrument/classes/GuardStateInserter.java
@@ -91,12 +91,13 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 		}
 	}
 	
-	/*
-	 * ADDITION BY NL
-	 */
+      
 	public void visitGetSelf(RRMethodAdapter mv, String owner, String name, String desc, boolean isStatic){
 		final Type ownerType = Type.getObjectType(owner);
 		Type selfType = Type.getType(desc);
+		
+		//put null on stack if accessed field is primitive
+		//pop reference to target from stack if accessed field is non-static
 		if(selfType.getSort() != Type.OBJECT && selfType.getSort() != Type.ARRAY){
 			if(!isStatic) {mv.visitInsn(POP);}
 			mv.visitInsn(ACONST_NULL);
@@ -134,17 +135,19 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			mv.visitVarInsn(ALOAD, 0);
 			// this
 			
-			/*ADDITION BY NL*/
-			visitGetSelf(mv, rrClass.getName(), name, desc, false);
-			mv.visitVarInsn(ALOAD, 0);
-			
+			//put refernce to accessed field on stack if values option isn't on
+			if(!RR.valuesOption.get()){
+			    visitGetSelf(mv, rrClass.getName(), name, desc, false);
+			    mv.visitVarInsn(ALOAD, 0);
+			}
+			//accessedRef this (if values option is not on)
 			
 			mv.visitVarInsn(ALOAD, 5);
-			// this gs
+			//accessedRef this gs
 			mv.visitVarInsn(ILOAD, 1 + valueSize);
-			// this gs fadid
+			//accessedRef this gs fadid
 			mv.visitVarInsn(ALOAD, 2 + valueSize);
-			// this gs fadid current 
+			//acessedRef this gs fadid current 
 
 			if (RR.valuesOption.get()) {
 				mv.visitVarInsn(ALOAD, 0);
@@ -193,9 +196,12 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 
 			mv.visitVarInsn(ALOAD, 0);
 			
-			/*ADDITION BY NL*/
-			visitGetSelf(mv, rrClass.getName(), name, desc, false);
-			mv.visitVarInsn(ALOAD, 0);
+		 
+			//put refernce to accessed field on stack if values option isn't on
+			if(!RR.valuesOption.get()){
+			    visitGetSelf(mv, rrClass.getName(), name, desc, false);
+			    mv.visitVarInsn(ALOAD, 0);
+			}
 			
 			
 			mv.visitVarInsn(ALOAD, 5);
@@ -243,11 +249,14 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			// insert fast path code.
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, true, 5, 1 + valueSize, success);
 			
-			/*ADDITION BY NL*/
-			visitGetSelf(mv, rrClass.getName(), name, desc, true);
-			
+			//put refernce to accessed field on stack if values option isn't on
+			if(!RR.valuesOption.get()){
+			    visitGetSelf(mv, rrClass.getName(), name, desc, true);
+			}
+			//accessedRef
 			mv.visitInsn(ACONST_NULL);
-			
+			//accessedRef null(target)
+
 			mv.visitVarInsn(ALOAD, 5);			
 			mv.visitVarInsn(ILOAD, 0 + valueSize);
 			mv.visitVarInsn(ALOAD, 1 + valueSize);
@@ -292,10 +301,13 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			// insert fast path code.
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, false, 5, 1, success);
 			
-			/*ADDITION BY NL*/
-			visitGetSelf(mv, rrClass.getName(), name, desc, true);
-			
+			//put refernce to accessed field on stack if values option isn't on
+			if(!RR.valuesOption.get()){
+			    visitGetSelf(mv, rrClass.getName(), name, desc, true);
+			}
+			//accessedRef
 			mv.visitInsn(ACONST_NULL);
+			//accessedRef null(target)
 
 			mv.visitVarInsn(ALOAD, 5);
 			mv.visitVarInsn(ILOAD, 0);

--- a/src/rr/instrument/classes/GuardStateInserter.java
+++ b/src/rr/instrument/classes/GuardStateInserter.java
@@ -90,6 +90,25 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			mv.getField(ownerType, shadowFieldName, Constants.GUARD_STATE_TYPE);
 		}
 	}
+	
+	/*
+	 * ADDITION BY NL
+	 */
+	public void visitGetSelf(RRMethodAdapter mv, String owner, String name, String desc, boolean isStatic){
+		final Type ownerType = Type.getObjectType(owner);
+		Type selfType = Type.getType(desc);
+		if(selfType.getSort() != Type.OBJECT){
+			mv.visitInsn(ACONST_NULL);
+		}
+		else{
+			if (isStatic){
+				mv.getStatic(ownerType, name, Type.getType(desc));
+			}
+			else{
+				mv.getField(ownerType, name, Type.getType(desc));
+			}
+		}
+	}
 
 	protected void addPutMethod(final int access, final String name, final String desc) {
 		ClassInfo rrClass = this.getCurrentClass();
@@ -101,7 +120,8 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 		mv.visitCode();
 		if ((access & ACC_FINAL) == 0) {
 			final Label success = new Label();
-
+			
+			
 			mv.visitVarInsn(ALOAD, 0);
 			// THIS
 			visitGetShadow(mv, rrClass.getName(), name, false);
@@ -112,6 +132,12 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			// 
 			mv.visitVarInsn(ALOAD, 0);
 			// this
+			
+			/*ADDITION BY NL*/
+			visitGetSelf(mv, rrClass.getName(), name, desc, false);
+			mv.visitVarInsn(ALOAD, 1);
+			
+			
 			mv.visitVarInsn(ALOAD, 5);
 			// this gs
 			mv.visitVarInsn(ILOAD, 1 + valueSize);
@@ -165,6 +191,12 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, false, 5, 2, success);
 
 			mv.visitVarInsn(ALOAD, 0);
+			
+			/*ADDITION BY NL*/
+			visitGetSelf(mv, rrClass.getName(), name, desc, false);
+			mv.visitVarInsn(ALOAD, 1);
+			
+			
 			mv.visitVarInsn(ALOAD, 5);
 			mv.visitVarInsn(ILOAD, 1);
 			mv.visitVarInsn(ALOAD, 2);
@@ -211,6 +243,10 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, true, 5, 1 + valueSize, success);
 
 			mv.visitInsn(ACONST_NULL);
+			
+			/*ADDITION BY NL*/
+			visitGetSelf(mv, rrClass.getName(), name, desc, true);
+			
 			mv.visitVarInsn(ALOAD, 5);			
 			mv.visitVarInsn(ILOAD, 0 + valueSize);
 			mv.visitVarInsn(ALOAD, 1 + valueSize);
@@ -256,6 +292,9 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, false, 5, 1, success);
 
 			mv.visitInsn(ACONST_NULL);
+			
+			/*ADDITION BY NL*/
+			visitGetSelf(mv, rrClass.getName(), name, desc, true);
 
 			mv.visitVarInsn(ALOAD, 5);
 			mv.visitVarInsn(ILOAD, 0);

--- a/src/rr/instrument/classes/GuardStateInserter.java
+++ b/src/rr/instrument/classes/GuardStateInserter.java
@@ -97,7 +97,7 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 	public void visitGetSelf(RRMethodAdapter mv, String owner, String name, String desc, boolean isStatic){
 		final Type ownerType = Type.getObjectType(owner);
 		Type selfType = Type.getType(desc);
-		if(selfType.getSort() != Type.OBJECT){
+		if(selfType.getSort() != Type.OBJECT && selfType.getSort() != Type.ARRAY){
 			if(!isStatic) {mv.visitInsn(POP);}
 			mv.visitInsn(ACONST_NULL);
 		}

--- a/src/rr/instrument/classes/GuardStateInserter.java
+++ b/src/rr/instrument/classes/GuardStateInserter.java
@@ -98,6 +98,7 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 		final Type ownerType = Type.getObjectType(owner);
 		Type selfType = Type.getType(desc);
 		if(selfType.getSort() != Type.OBJECT){
+			if(!isStatic) {mv.visitInsn(POP);}
 			mv.visitInsn(ACONST_NULL);
 		}
 		else{
@@ -135,7 +136,7 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			
 			/*ADDITION BY NL*/
 			visitGetSelf(mv, rrClass.getName(), name, desc, false);
-			mv.visitVarInsn(ALOAD, 1);
+			mv.visitVarInsn(ALOAD, 0);
 			
 			
 			mv.visitVarInsn(ALOAD, 5);
@@ -194,7 +195,7 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			
 			/*ADDITION BY NL*/
 			visitGetSelf(mv, rrClass.getName(), name, desc, false);
-			mv.visitVarInsn(ALOAD, 1);
+			mv.visitVarInsn(ALOAD, 0);
 			
 			
 			mv.visitVarInsn(ALOAD, 5);
@@ -241,11 +242,11 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 			mv.visitVarInsn(ASTORE, 5);
 			// insert fast path code.
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, true, 5, 1 + valueSize, success);
-
-			mv.visitInsn(ACONST_NULL);
 			
 			/*ADDITION BY NL*/
 			visitGetSelf(mv, rrClass.getName(), name, desc, true);
+			
+			mv.visitInsn(ACONST_NULL);
 			
 			mv.visitVarInsn(ALOAD, 5);			
 			mv.visitVarInsn(ILOAD, 0 + valueSize);
@@ -290,11 +291,11 @@ public class GuardStateInserter extends RRClassAdapter implements Opcodes {
 
 			// insert fast path code.
 			if (!isVolatile) ASMUtil.insertFastPathCode(mv, false, 5, 1, success);
-
-			mv.visitInsn(ACONST_NULL);
 			
 			/*ADDITION BY NL*/
 			visitGetSelf(mv, rrClass.getName(), name, desc, true);
+			
+			mv.visitInsn(ACONST_NULL);
 
 			mv.visitVarInsn(ALOAD, 5);
 			mv.visitVarInsn(ILOAD, 0);

--- a/src/rr/instrument/methods/FancyArrayInstructionAdapter.java
+++ b/src/rr/instrument/methods/FancyArrayInstructionAdapter.java
@@ -222,13 +222,27 @@ public class FancyArrayInstructionAdapter extends GuardStateInstructionAdapter i
 
 					super.visitVarInsn(ALOAD, this.arrayLoc);
 					super.visitVarInsn(ILOAD, this.indexLoc);
-					// index target 
+					
+					
+					// index target
+					/*ADDITION BY NL*/
+					//push reference at index of target (if reference type) and null otherwise
+					if(opcode == AALOAD){
+						this.visitInsn(DUP2);
+						mv.visitInsn(AALOAD);
+					}
+					else{
+						mv.visitInsn(ACONST_NULL);
+					}
+					/*ADDITION BY NL*/
+					
+					//accessedReference index target
 					this.push(access.getId());
-					// arrayAccessDataid index target 
+					// arrayAccessDataid accessedReference index target 
 					super.visitVarInsn(ALOAD, threadDataLoc);				
-					// ShadowThread arrayAccessDataid index target   
+					// ShadowThread arrayAccessDataid accessedReference index target   
 					super.visitVarInsn(ALOAD, locForArrayShadow(v.id));				
-					// ArrayShadow ShadowThread arrayAccessDataid index target   
+					// ArrayShadow ShadowThread arrayAccessDataid accessedReference index target   
 					this.invokeStatic(Constants.MANAGER_TYPE, Constants.READ_ARRAY_WITH_UPDATER_METHOD);
 					// 
 					this.visitLabel(success);
@@ -318,7 +332,22 @@ public class FancyArrayInstructionAdapter extends GuardStateInstructionAdapter i
 					//
 					super.visitVarInsn(ALOAD, this.arrayLoc);
 					super.visitVarInsn(ILOAD, this.indexLoc);
-					// index target 
+					
+					
+					// index target
+					/*ADDITION BY NL*/
+					//push reference at index of target (if reference type) and null otherwise
+					if(opcode == AASTORE){
+						this.visitInsn(DUP2);
+						mv.visitInsn(AALOAD);
+					}
+					else{
+						mv.visitInsn(ACONST_NULL);
+					}
+					/*ADDITION BY NL*/
+					
+					
+					// accessedReference index target 
 					this.push(access.getId());
 					// arrayAccessDataid index target 
 					super.visitVarInsn(ALOAD, threadDataLoc);				

--- a/src/rr/instrument/methods/FancyArrayInstructionAdapter.java
+++ b/src/rr/instrument/methods/FancyArrayInstructionAdapter.java
@@ -172,6 +172,21 @@ public class FancyArrayInstructionAdapter extends GuardStateInstructionAdapter i
 		return -1;
 	}
 
+	private void putAccessed(int opcode){
+		//stack state = index target
+		if(opcode == AALOAD || opcode == AASTORE){	
+			this.visitInsn(DUP2);
+			//index target index target
+			//called on mv (not this) so this.visitArrayInsn is not called as a consequence
+			mv.visitInsn(AALOAD);
+			//accessedReference index target
+			
+		}
+		else{
+			mv.visitInsn(ACONST_NULL);
+			//null index target
+		}
+	}
 	@Override
 	protected void visitArrayInsn(int opcode) {
 		boolean old = inInstrumentationCode;
@@ -225,16 +240,7 @@ public class FancyArrayInstructionAdapter extends GuardStateInstructionAdapter i
 					
 					
 					// index target
-					/*ADDITION BY NL*/
-					//push reference at index of target (if reference type) and null otherwise
-					if(opcode == AALOAD){
-						this.visitInsn(DUP2);
-						mv.visitInsn(AALOAD);
-					}
-					else{
-						mv.visitInsn(ACONST_NULL);
-					}
-					/*ADDITION BY NL*/
+					putAccessed(opcode);
 					
 					//accessedReference index target
 					this.push(access.getId());
@@ -335,17 +341,7 @@ public class FancyArrayInstructionAdapter extends GuardStateInstructionAdapter i
 					
 					
 					// index target
-					/*ADDITION BY NL*/
-					//push reference at index of target (if reference type) and null otherwise
-					if(opcode == AASTORE){
-						this.visitInsn(DUP2);
-						mv.visitInsn(AALOAD);
-					}
-					else{
-						mv.visitInsn(ACONST_NULL);
-					}
-					/*ADDITION BY NL*/
-					
+					putAccessed(opcode);
 					
 					// accessedReference index target 
 					this.push(access.getId());

--- a/src/rr/instrument/methods/SimpleArrayInstructionAdapter.java
+++ b/src/rr/instrument/methods/SimpleArrayInstructionAdapter.java
@@ -56,7 +56,7 @@ import acme.util.Assert;
 import acme.util.Util;
 
 public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter implements Opcodes {
-
+	
 	public SimpleArrayInstructionAdapter(final MethodVisitor mv, MethodInfo m) {
 		super(mv, m);
 	}
@@ -103,13 +103,32 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 
 					// index target
 					this.visitInsn(DUP2);
+					
 					// index target index target
+					/*ADDITION BY NL*/
+					//push reference at index of target (if reference type) and null otherwise
+					if(opcode == AALOAD){
+						mv.visitInsn(AALOAD);
+					}
+					else{
+						this.visitInsn(POP2);
+						mv.visitInsn(ACONST_NULL);
+					}
+					//accessedReference index target
+					this.visitVarInsn(ASTORE, threadDataLoc + 1);
+					//index target
+					this.visitInsn(DUP2);
+					//index target index target
+					this.visitVarInsn(ALOAD, threadDataLoc + 1);
+					
+					
+					//accessedReference index target index target
 					this.push(access.getId());
-					// arrayAccessDataid index target index target
+					// arrayAccessDataid accessedReference index target index target
 					this.visitVarInsn(ALOAD, threadDataLoc);				
-					// ShadowThread arrayAccessDataid index target index target  
+					// ShadowThread arrayAccessDataid index accessedReference target index target  
 					this.visitVarInsn(ALOAD, threadDataLoc+5);				
-					// ShadowVar ShadowThread arrayAccessDataid index target index target  
+					// ShadowVar ShadowThread arrayAccessDataid accessedReference index target index target  
 					this.invokeStatic(Constants.MANAGER_TYPE, Constants.READ_ARRAY_WITH_UPDATER_METHOD);
 					// index target
 
@@ -117,11 +136,30 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 				} else {
 					// index target
 					this.visitInsn(DUP2);
+					
+					
 					// index target index target
+					/*ADDITION BY NL*/
+					//push reference at index of target (if reference type) and null otherwise
+					if(opcode == AALOAD){
+						mv.visitInsn(AALOAD);
+					}
+					else{
+						this.visitInsn(POP2);
+						mv.visitInsn(ACONST_NULL);
+					}
+					//accessedReference index target
+					this.visitVarInsn(ASTORE, threadDataLoc + 1);
+					//index target
+					this.visitInsn(DUP2);
+					//index target index target
+					this.visitVarInsn(ALOAD, threadDataLoc + 1);
+					
+					//accessedReference index target index target
 					this.push(access.getId());
-					// arrayAccessDataid index target index target
+					// arrayAccessDataid accessedReference index target index target
 					this.visitVarInsn(ALOAD, threadDataLoc);				
-					// ShadowThread arrayAccessDataid index target index target  
+					// ShadowThread arrayAccessDataid accessedReference index target index target  
 					this.invokeStatic(Constants.MANAGER_TYPE, Constants.READ_ARRAY_METHOD);
 					// index target
 				} 
@@ -182,28 +220,65 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 
 					// index target value
 					this.visitInsn(DUP2);
+					
+					
+					
 					// index target index target value
+					/*ADDITION BY NL*/
+					//push reference at index of target (if reference type) and null otherwise
+					if(opcode == AASTORE){
+						mv.visitInsn(AALOAD);
+					}
+					else{
+						this.visitInsn(POP2);
+						mv.visitInsn(ACONST_NULL);
+					}
+					//accessedReference index target value
+					this.visitVarInsn(ASTORE, threadDataLoc + 1);
+					//index target value
+					this.visitInsn(DUP2);
+					//index target index target value
+					this.visitVarInsn(ALOAD, threadDataLoc + 1);
+					
+					//accessedReference index target index target value
 					this.push(access.getId());
-					// arrayAccessDataid index target index target value
+					// arrayAccessDataid accessedReference index target index target value
 					this.visitVarInsn(ALOAD, threadDataLoc);				
-					// ShadowThread arrayAccessDataid index target index target value  
+					// ShadowThread arrayAccessDataid accessedReference index target index target value  
 					this.visitVarInsn(ALOAD, threadDataLoc+5);				
-					// ShadowVar ShadowThread arrayAccessDataid index target index target value  
+					// ShadowVar ShadowThread arrayAccessDataid accessedReference index target index target value  
 					this.invokeStatic(Constants.MANAGER_TYPE, Constants.WRITE_ARRAY_WITH_UPDATER_METHOD);
 					// index target value
 					this.visitLabel(success);
 				} else {
-
 					this.visitInsn(DUP2);
+					
+					
 					// index target index target value
+					/*ADDITION BY NL*/
+					//push reference at index of target (if reference type) and null otherwise
+					if(opcode == AASTORE){
+						mv.visitInsn(AALOAD);
+					}
+					else{
+						this.visitInsn(POP2);
+						mv.visitInsn(ACONST_NULL);
+					}
+					//accessedReference index target value
+					this.visitVarInsn(ASTORE, threadDataLoc + 1);
+					//index target value
+					this.visitInsn(DUP2);
+					//index target index target value
+					this.visitVarInsn(ALOAD, threadDataLoc + 1);
+					
+					//accessedReference index target index target value
 					push(access.getId());
-					// arrayAccessDataid index target index target value
+					// arrayAccessDataid accessedReference index target index target value
 					this.visitVarInsn(ALOAD, threadDataLoc);				
-					// ShadowThread arrayAccessDataid index target index target value
+					// ShadowThread arrayAccessDataid accessedReference index target index target value
 					this.invokeStatic(Constants.MANAGER_TYPE, Constants.WRITE_ARRAY_METHOD);
 					// index target value
 				}
-
 				if (doubleSize) {
 					// index target value value
 					this.visitInsn(DUP2_X2);
@@ -220,6 +295,6 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 			}
 			default:
 				Assert.panic("Not an target opcode!");
-		}	
+		}
 	}
 }

--- a/src/rr/instrument/methods/SimpleArrayInstructionAdapter.java
+++ b/src/rr/instrument/methods/SimpleArrayInstructionAdapter.java
@@ -61,6 +61,27 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 		super(mv, m);
 	}
 
+	private void putAccessed(int opcode){
+		if(opcode == AALOAD || opcode == AASTORE){
+			//push reference at index of target (if reference type) and null otherwise
+			//called on mv (not this) so this.visitArrayInsn is not called as a consequence
+			mv.visitInsn(AALOAD);
+			
+			//accessedReference index target
+			this.visitVarInsn(ASTORE, threadDataLoc + 1);
+			//index target
+			this.visitInsn(DUP2);
+			//index target index target
+			this.visitVarInsn(ALOAD, threadDataLoc + 1);
+			//accessedReference index target index target
+		}
+		else{
+			this.visitInsn(ACONST_NULL);
+			//null index target index target
+		}
+		
+		return;
+	}
 
 	@Override
 	protected void visitArrayInsn(int opcode) {
@@ -105,22 +126,7 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 					this.visitInsn(DUP2);
 					
 					// index target index target
-					/*ADDITION BY NL*/
-					//push reference at index of target (if reference type) and null otherwise
-					if(opcode == AALOAD){
-						mv.visitInsn(AALOAD);
-					}
-					else{
-						this.visitInsn(POP2);
-						mv.visitInsn(ACONST_NULL);
-					}
-					//accessedReference index target
-					this.visitVarInsn(ASTORE, threadDataLoc + 1);
-					//index target
-					this.visitInsn(DUP2);
-					//index target index target
-					this.visitVarInsn(ALOAD, threadDataLoc + 1);
-					
+					putAccessed(opcode);
 					
 					//accessedReference index target index target
 					this.push(access.getId());
@@ -137,24 +143,8 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 					// index target
 					this.visitInsn(DUP2);
 					
-					
 					// index target index target
-					/*ADDITION BY NL*/
-					//push reference at index of target (if reference type) and null otherwise
-					if(opcode == AALOAD){
-						mv.visitInsn(AALOAD);
-					}
-					else{
-						this.visitInsn(POP2);
-						mv.visitInsn(ACONST_NULL);
-					}
-					//accessedReference index target
-					this.visitVarInsn(ASTORE, threadDataLoc + 1);
-					//index target
-					this.visitInsn(DUP2);
-					//index target index target
-					this.visitVarInsn(ALOAD, threadDataLoc + 1);
-					
+					putAccessed(opcode);
 					//accessedReference index target index target
 					this.push(access.getId());
 					// arrayAccessDataid accessedReference index target index target
@@ -224,22 +214,7 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 					
 					
 					// index target index target value
-					/*ADDITION BY NL*/
-					//push reference at index of target (if reference type) and null otherwise
-					if(opcode == AASTORE){
-						mv.visitInsn(AALOAD);
-					}
-					else{
-						this.visitInsn(POP2);
-						mv.visitInsn(ACONST_NULL);
-					}
-					//accessedReference index target value
-					this.visitVarInsn(ASTORE, threadDataLoc + 1);
-					//index target value
-					this.visitInsn(DUP2);
-					//index target index target value
-					this.visitVarInsn(ALOAD, threadDataLoc + 1);
-					
+					putAccessed(opcode);
 					//accessedReference index target index target value
 					this.push(access.getId());
 					// arrayAccessDataid accessedReference index target index target value
@@ -255,21 +230,8 @@ public class SimpleArrayInstructionAdapter extends GuardStateInstructionAdapter 
 					
 					
 					// index target index target value
-					/*ADDITION BY NL*/
-					//push reference at index of target (if reference type) and null otherwise
-					if(opcode == AASTORE){
-						mv.visitInsn(AALOAD);
-					}
-					else{
-						this.visitInsn(POP2);
-						mv.visitInsn(ACONST_NULL);
-					}
-					//accessedReference index target value
-					this.visitVarInsn(ASTORE, threadDataLoc + 1);
-					//index target value
-					this.visitInsn(DUP2);
-					//index target index target value
-					this.visitVarInsn(ALOAD, threadDataLoc + 1);
+					putAccessed(opcode);
+					
 					
 					//accessedReference index target index target value
 					push(access.getId());

--- a/src/rr/replay/RRReplay.java
+++ b/src/rr/replay/RRReplay.java
@@ -163,9 +163,9 @@ public class RRReplay implements MetaDataInfoVisitor {
 						final Object obj = object(target);
 						final ShadowVar state = fad.getField().getUpdater().getState(obj);
 						if (fad.isWrite()) {
-							if (doIt) 	RREventGenerator.volatileWriteAccess(obj, state, fad.getId(), thread(thread));
+							if (doIt) 	RREventGenerator.volatileWriteAccess(null, obj, state, fad.getId(), thread(thread));
 						} else {
-							if (doIt) RREventGenerator.volatileReadAccess(obj, state, fad.getId(), thread(thread));
+							if (doIt) RREventGenerator.volatileReadAccess(null, obj, state, fad.getId(), thread(thread));
 						}
 						break;
 					} 
@@ -176,10 +176,10 @@ public class RRReplay implements MetaDataInfoVisitor {
 						final ShadowVar state = fad.getField().getUpdater().getState(obj);
 						if (fad.isWrite()) {
 							if (doIt) {
-								RREventGenerator.writeAccess(obj, state, fad.getId(), thread(thread));
+								RREventGenerator.writeAccess(null, obj, state, fad.getId(), thread(thread));
 							}
 						} else {
-							if (doIt) RREventGenerator.readAccess(obj, state, fad.getId(), thread(thread));
+							if (doIt) RREventGenerator.readAccess(null, obj, state, fad.getId(), thread(thread));
 						}
 						break;
 					} 
@@ -191,9 +191,9 @@ public class RRReplay implements MetaDataInfoVisitor {
 						}
 						Assert.assertTrue(fad != null, "Bad MetaData for " + accessKey);
 						if (fad.isWrite()) {
-							if (doIt) RREventGenerator.arrayWrite(array(target), index, fad.getId(), thread(thread), array(target));
+							if (doIt) RREventGenerator.arrayWrite(array(target), index, null, fad.getId(), thread(thread), array(target));
 						} else {
-							if (doIt) RREventGenerator.arrayRead(array(target), index, fad.getId(), thread(thread), array(target));
+							if (doIt) RREventGenerator.arrayRead(array(target), index, null, fad.getId(), thread(thread), array(target));
 						}
 						break;
 					}


### PR DESCRIPTION
Adds an "accessed" field to the AccessEvent class that holds a reference to the field that triggered a read or write access call back, if that field is a reference or array type and null otherwise. Compatible with volatile, array, and normal field accesses. Not implemented to work with the values option.  
