### PR TITLE
Migrate build tool list generator from legacy APT to new JSR269 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+auto
+build
+classes
+classes-test
+docs

--- a/build.xml
+++ b/build.xml
@@ -116,6 +116,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			<compilerarg value="-Xbootclasspath/p:${classes.dir}" />
 			<compilerarg value="-XDignore.symbol.file" />
 		</javac>
+		<echo file="${classes.dir}/META-INF/services/javax.annotation.processing.Processor" append="false" message="rr.annotations.BuildToolList" />
 		<echo file="${auto.dir}/bin/${run-script}" append="false" message="#!/bin/bash${line.separator}
 								  ${java.home}/bin/java -version ${line.separator}
 			                      echo ${line.separator}
@@ -127,13 +128,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 	<target name="props" depends="">
-		<apt factorypathref="rr.classpath" compile="false" classpathref="rr.classpath" factory="rr.annotations.BuildToolList" srcdir="${src.dir}/tools">
+		<javac classpathref="rr.classpath" srcdir="${src.dir}/tools">
+		  <compilerarg value="-proc:only" />
 		  <compilerarg value="-XDignore.symbol.file" />
-		</apt>
-
+		</javac>
 		<move file="rrtools.properties" todir="${classes.dir}/tools" />
 
-		<apt factorypathref="rr.classpath" compile="false" classpathref="rr.classpath" factory="rr.annotations.BuildToolList" srcdir="${src.dir}/rr/simple" />
+		<javac classpathref="rr.classpath" srcdir="${src.dir}/rr/simple">
+		  <compilerarg value="-proc:only" />
+		  <compilerarg value="-XDignore.symbol.file" />
+		</javac>
 		<move file="rrtools.properties" todir="${classes.dir}/rr/simple" />
 	</target>
 

--- a/src/rr/annotations/BuildToolList.java
+++ b/src/rr/annotations/BuildToolList.java
@@ -38,25 +38,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package rr.annotations;
 
-import static com.sun.mirror.util.DeclarationVisitors.NO_OP;
-import static com.sun.mirror.util.DeclarationVisitors.getDeclarationScanner;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableCollection;
-
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Set;
 
-import com.sun.mirror.apt.AnnotationProcessor;
-import com.sun.mirror.apt.AnnotationProcessorEnvironment;
-import com.sun.mirror.apt.AnnotationProcessorFactory;
-import com.sun.mirror.declaration.AnnotationTypeDeclaration;
-import com.sun.mirror.declaration.ClassDeclaration;
-import com.sun.mirror.declaration.TypeDeclaration;
-import com.sun.mirror.util.SimpleDeclarationVisitor;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
 
 /**
  * This class is used to run an annotation processor that lists class
@@ -64,64 +57,28 @@ import com.sun.mirror.util.SimpleDeclarationVisitor;
  * can be used when specifying the tool chain.  See the Tool class for more
  * info.
  */
-public class BuildToolList implements AnnotationProcessorFactory {
-	// Process any set of annotations
-	private static final Collection<String> supportedAnnotations = unmodifiableCollection(Arrays.asList("*"));
-
-	// No supported options
-	private static final Collection<String> supportedOptions = emptySet();
-
-	public Collection<String> supportedAnnotationTypes() {
-		return supportedAnnotations;
+@SupportedAnnotationTypes({"rr.annotations.Abbrev"})
+public class BuildToolList extends AbstractProcessor {
+	private PrintWriter out;
+	
+	public BuildToolList() throws IOException {
+		out = new PrintWriter(new FileWriter("rrtools.properties"));
+	}
+	
+	@Override
+	public SourceVersion getSupportedSourceVersion() {
+		return SourceVersion.latestSupported();
 	}
 
-	public Collection<String> supportedOptions() {
-		return supportedOptions;
-	}
-
-	public AnnotationProcessor getProcessorFor(Set<AnnotationTypeDeclaration> atds, AnnotationProcessorEnvironment env) {
-		return new ListClassAp(env);
-	}
-
-	private static class ListClassAp implements AnnotationProcessor {
-
-		private final AnnotationProcessorEnvironment env;
-		protected PrintWriter out;
-
-		ListClassAp(AnnotationProcessorEnvironment env) {
-			this.env = env;
-			try {
-				out = new PrintWriter(new FileWriter("rrtools.properties"));
-			} catch (IOException e) {
-				e.printStackTrace();
-				System.exit(1);
+	public boolean process(Set<? extends TypeElement> annotations,
+              RoundEnvironment env) {
+		for (Element e : env.getElementsAnnotatedWith(Abbrev.class)) {
+			TypeElement te = (TypeElement)e;
+			Abbrev a = te.getAnnotation(Abbrev.class);
+			if (a != null) {
+				out.println(a.value() + "=" + te.getQualifiedName());
 			}
 		}
-
-		public void process() {
-			for (TypeDeclaration typeDecl : env.getSpecifiedTypeDeclarations())
-				typeDecl.accept(getDeclarationScanner(new ListClassVisitor(),
-						NO_OP));
-			out.close();
-		}
-
-		private class ListClassVisitor extends SimpleDeclarationVisitor {
-			@Override
-			public void visitClassDeclaration(ClassDeclaration d) {
-				Abbrev a = d.getAnnotation(Abbrev.class);
-//				File file = d.getPosition().file();
-//				try {
-//					final String command = "wcb " + file.getAbsolutePath();
-//					Process p = Runtime.getRuntime().exec(command);
-//					DataInputStream in = new DataInputStream(p.getInputStream());
-//					System.out.println(d.getQualifiedName() + " " + in.readLine());
-//				} catch (Exception e) {
-//					Assert.fail(e);
-//				}
-				if (a != null) {
-					out.println(a.value() + "=" + d.getQualifiedName());
-				}
-			}
-		}
+		return true;
 	}
 }


### PR DESCRIPTION
The current version of RoadRunner uses `com.sun.mirror.apt.AnnotationProcessor` which has been [deprecated in Java 7](https://docs.oracle.com/javase/7/docs/technotes/guides/apt/GettingStarted.html#deprecated) and completely removed in Java 8.

In order to make RoadRunner work with Java 8, this PR rewrote the build tool list generator using the JSR269 Pluggable Annotation Processing API (`javax.annotation.processing`) which was introduced with Java 6.
